### PR TITLE
修正: Connectednessセクションの閉じがない

### DIFF
--- a/top_space.v
+++ b/top_space.v
@@ -123,3 +123,4 @@ Proof.
   apply H5.
 Qed.
 
+End Connectedness.


### PR DESCRIPTION
top_space.vにおいて、Connectednessセクションの閉じがなかったためコンパイルエラーになっていたのを修正しました。

## 動作確認方法

```console
coqc top_space.v
```

## 環境

以下のバージョンで作業しました。

- macOS Sierra 10.12.6
- coq version 8.7
