### PR TITLE
makeで一括ビルドできるようにした

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,0 +1,5 @@
+finset.v
+subset.v
+top_space.v
+presheaf.v
+presheaf2.v

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eux
+coq_makefile -f _CoqProject -o Makefile


### PR DESCRIPTION
`coq_makefile` というcoq付属のツールを使って make一発でプロジェクト全体のビルドをできるようにしました。

## 使い方

```console
./configure.sh
make
```

またcoqdocによるhtmlなども生成できます。
```console
make html
open html/index.html
```

## Coqのソースファイルが増えたり減ったりしたとき

は、 `_CoqProject` を修正してください。

## 環境
私の作業環境は以下の通りです。

- macOS Sierra 10.12.6
- coq version 8.7
- make: GNU Make 3.81